### PR TITLE
feat(skills): Add sheet parent state re-initialization pattern

### DIFF
--- a/.claude-plugin/plugins/axiom/skills/axiom-swiftui-architecture/SKILL.md
+++ b/.claude-plugin/plugins/axiom/skills/axiom-swiftui-architecture/SKILL.md
@@ -973,6 +973,31 @@ var body: some View {
 }
 ```
 
+## ❌ Anti-Pattern 7: Mutating Parent State That Flows Back as Child Init Params
+
+Any `@ViewBuilder` closure (`.sheet`, `.fullScreenCover`, `NavigationStack` destination, `.popover`) re-evaluates when parent state changes. If a child callback mutates the same parent `@State` that's passed as a child init parameter, the child gets re-initialized with changed values mid-lifecycle.
+
+```swift
+// ❌ Callback mutates the same state passed as init param
+.sheet(item: $sheetItem) { item in
+    ChildView(
+        savedResponse: cachedResponse,      // ❌ Parent state as init param
+        onSuccess: { cachedResponse = $0 }  // ❌ Mutates same state
+    )
+}
+// onSuccess fires → cachedResponse set → parent re-evaluates → closure re-evaluates
+// → new ChildView struct with savedResponse now non-nil → loading/animations skipped
+
+// ✅ Don't pass state that callbacks will mutate
+.sheet(item: $sheetItem) { item in
+    ChildView(
+        onSuccess: { cachedResponse = $0 }  // Update parent, but don't read it back
+    )
+}
+```
+
+**Fixes**: (1) Don't pass the mutated state back as an init param. (2) Use a separate `@State` for the child's display logic. (3) Have the child query its own data source. See Root Cause 5 in `axiom-swiftui-debugging` for full diagnostic workflow.
+
 ---
 
 # Code Review Checklist

--- a/.claude-plugin/plugins/axiom/skills/axiom-swiftui-debugging/SKILL.md
+++ b/.claude-plugin/plugins/axiom/skills/axiom-swiftui-debugging/SKILL.md
@@ -41,6 +41,9 @@ These are real questions developers ask that this skill is designed to answer:
 #### 5. "Text field loses focus when I start typing, very frustrating"
 → The skill identifies ForEach identity issues and shows how to use stable IDs
 
+#### 6. "My sheet/modal always skips its loading animation and shows the completed state"
+→ The skill identifies @ViewBuilder closure re-initialization from parent state changes causing init params to change
+
 ## When to Use SwiftUI Debugging
 
 #### Use this skill when
@@ -402,6 +405,62 @@ struct ContentView: View {
 
 ---
 
+#### Root Cause 5: @ViewBuilder Closure Re-Initialization
+
+**Symptom**: A child view in a `.sheet`, `.fullScreenCover`, `.popover`, or `NavigationStack` destination never shows expected loading states or animations — it always appears in the "completed" state. A callback updates parent state, and the child behaves as if data was already loaded.
+
+**Why it happens**: Any `@ViewBuilder` closure re-evaluates when the parent body re-evaluates. If you pass parent `@State` as a child init parameter, and a callback mutates that same state, the closure re-evaluates with the new value. The child `@State` is preserved (WWDC 2021 "Demystify SwiftUI" — identity-based lifetime), but init parameters are recomputed.
+
+```swift
+// ❌ WRONG: Parent state passed to child, then mutated by child callback
+.sheet(item: $sheetData) { data in
+    ChildView(
+        savedResponse: cachedResponse,      // Parent state as init param
+        onSuccess: { cachedResponse = $0 }  // Callback mutates same state
+    )
+}
+// 1. Sheet opens → ChildView(savedResponse: nil)
+// 2. Async completes → onSuccess fires → cachedResponse set
+// 3. Parent body re-evaluates → closure re-evaluates
+// 4. New ChildView(savedResponse: cachedResponse) — now non-nil
+// 5. Child takes "pre-loaded" path → animations always skipped
+```
+
+**Diagnosis**: Add `let _ = Self._printChanges()` to both parent and child. If the child's init params change after its own callback fires, this is the cause.
+
+**Fixes** (simplest first):
+1. **Don't pass it back**: Remove the mutated state from init params — let the callback update parent without flowing it back
+2. **Separate state**: Use a different `@State` for the child's display logic vs the parent's cache
+3. **Child-owned lookup**: Child queries its own data source instead of receiving parent state
+
+```swift
+// ✅ Fix 1: Don't pass the mutated state back as init param
+.sheet(item: $sheetData) { data in
+    ChildView(
+        onSuccess: { cachedResponse = $0 }  // Updates parent, doesn't flow back
+    )
+}
+
+// ✅ Fix 2: Separate state for display vs cache
+@State private var cachedResponse: Response?    // Parent's cache
+@State private var childInitResponse: Response? // Captured at sheet open time
+
+Button("Open") {
+    childInitResponse = cachedResponse  // Snapshot once
+    sheetData = SheetData()
+}
+.sheet(item: $sheetData) { data in
+    ChildView(
+        savedResponse: childInitResponse,       // Stable — not mutated by callback
+        onSuccess: { cachedResponse = $0 }
+    )
+}
+```
+
+**Key insight**: This is not sheet-specific — it applies to any `@ViewBuilder` closure. The child's `@State` persists across re-evaluations, but init parameters are recomputed with current parent state.
+
+---
+
 ### Decision Tree Summary
 
 ```dot
@@ -418,6 +477,7 @@ digraph view_not_updating {
     cause -> "Lost Binding Identity" [label="passed binding to child"];
     cause -> "Accidental Recreation" [label="view inside conditional"];
     cause -> "Missing Observer" [label="object changed, view didn't"];
+    cause -> "Sheet/Closure Re-Init" [label="closure re-evaluated with changed parent state"];
 }
 ```
 


### PR DESCRIPTION
## Summary

Adds documentation for a non-obvious SwiftUI gotcha that caused a real bug in production: **parent `@State` changes cause sheet content closures to re-evaluate, reinitializing child views with different init parameters**.

This addresses issue #9.

## Changes

### `axiom-swiftui-debugging`
- **Root Cause 5: Sheet Content Re-Initialization** — New diagnostic pattern
- New example prompt: "My scroll reveal animation never works - it shows the revealed state immediately"
- Updated decision tree summary to include this pattern
- Full code examples showing the broken pattern, the mechanism, and the fix

### `axiom-swiftui-architecture`  
- **Anti-Pattern 5: Passing Mutable Parent State as Sheet Init Params**
- Code examples showing the pattern and why features are broken from the start
- Correct patterns using database lookup for caching instead of parent-passed state

## The Bug This Documents

```swift
// ❌ This pattern breaks features ENTIRELY (not "works then breaks")
.sheet(item: $sheetItem) { item in
    ChildView(
        savedResponse: cachedResponse,      // Parent state as init param
        onSuccess: { cachedResponse = $0 }  // Callback mutates same state
    )
}
```

What happens:
1. Sheet opens → `ChildView` created with `savedResponse: nil`
2. Async completes → `onSuccess` fires → `cachedResponse` set
3. SwiftUI sees `@State` mutation → re-evaluates parent body
4. Sheet content closure re-evaluates → **new** `ChildView` created
5. New struct sees `savedResponse: cachedResponse` (now non-nil!)
6. Child takes "pre-loaded" path → **always** skips loading/animations

The key insight: the feature is broken from the start because by the time the child checks its init params, they've already been changed by the callback.

## Testing

- Verified existing skill content unchanged
- New patterns follow existing skill formatting conventions
- Links to related issue #9

Closes #9