### PR TITLE
fix(commands/status): use pgrep -x for exact xcodebuild process matching

### DIFF
--- a/.claude-plugin/plugins/axiom/commands/status.md
+++ b/.claude-plugin/plugins/axiom/commands/status.md
@@ -11,7 +11,7 @@ Run these checks and format as a dashboard:
 ### Environment Health
 ```bash
 # Zombie processes
-pgrep -f xcodebuild | wc -l
+pgrep -x xcodebuild | wc -l
 
 # Derived Data size
 du -sh ~/Library/Developer/Xcode/DerivedData 2>/dev/null


### PR DESCRIPTION
Fixes #30

## What type of PR is this?

- bug

## What this PR does / why it is needed:

The zombie process check in the status command used `pgrep -f xcodebuild` which matches against the full command line. This caused false positives on `xcodebuildmcp` MCP server processes (e.g., `npm exec xcodebuildmcp@latest mcp`), reporting 14+ "zombie xcodebuild processes" when in reality no xcodebuild processes were running.

Changing to `pgrep -x xcodebuild` does exact process name matching, eliminating false positives from any process whose command line merely contains the substring "xcodebuild".

## Changes:

- `.claude-plugin/plugins/axiom/commands/status.md`: `pgrep -f xcodebuild` → `pgrep -x xcodebuild`
