### PR TITLE
fix(hooks): Fix heredoc comment for macos bash 3.2 compatiblity

### DIFF
--- a/.claude-plugin/plugins/axiom/hooks/user-prompt-submit.sh
+++ b/.claude-plugin/plugins/axiom/hooks/user-prompt-submit.sh
@@ -10,7 +10,7 @@ import sys
 
 # Read full payload from stdin — argv path hits the ~256KB-1MB platform limit
 # on large pasted prompts. Python source is delivered via -c so sys.stdin
-# remains the parent shell's stdin (the JSON payload from Claude Code).
+# remains the parent shell stdin (the JSON payload from Claude Code).
 try:
     input_data = json.load(sys.stdin)
     prompt = input_data.get("prompt", "")


### PR DESCRIPTION
Fixes #37 

```
"${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt-submit.sh"]: ~/.claude/plugins/cache/axiom-marketplace/axiom/3.3.2/hooks/user-prompt-submit.sh: line 149: unexpected EOF while looking for matching `''
  ~/.claude/plugins/cache/axiom-marketplace/axiom/3.3.2/hooks/user-prompt-submit.sh: line 179: syntax error: unexpected end of file
```